### PR TITLE
Add response dates to all return types

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,14 +60,17 @@ repository.get('oai:www.example.com:12345')
   * [`#admin_emails`](#fieldhandidentifyadmin_emails)
   * [`#compression`](#fieldhandidentifycompression)
   * [`#descriptions`](#fieldhandidentifydescriptions)
+  * [`#response_date`](#fieldhandidentifyresponse_date)
 * [`Fieldhand::MetadataFormat`](#fieldhandmetadataformat)
   * [`#prefix`](#fieldhandmetadataformatprefix)
   * [`#schema`](#fieldhandmetadataformatschema)
   * [`#namespace`](#fieldhandmetadataformatnamespace)
+  * [`#response_date`](#fieldhandmetadataformatresponse_date)
 * [`Fieldhand::Set`](#fieldhandset)
   * [`#spec`](#fieldhandsetspec)
   * [`#name`](#fieldhandsetname)
   * [`#descriptions`](#fieldhandsetdescriptions)
+  * [`#response_date`](#fieldhandsetresponse_date)
 * [`Fieldhand::Record`](#fieldhandrecord)
   * [`#deleted?`](#fieldhandrecorddeleted)
   * [`#status`](#fieldhandrecordstatus)
@@ -76,12 +79,14 @@ repository.get('oai:www.example.com:12345')
   * [`#sets`](#fieldhandrecordsets)
   * [`#metadata`](#fieldhandrecordmetadata)
   * [`#about`](#fieldhandrecordabout)
+  * [`#response_date`](#fieldhandrecordresponse_date)
 * [`Fieldhand::Header`](#fieldhandheader)
   * [`#deleted?`](#fieldhandheaderdeleted)
   * [`#status`](#fieldhandheaderstatus)
   * [`#identifier`](#fieldhandheaderidentifier)
   * [`#datestamp`](#fieldhandheaderdatestamp)
   * [`#sets`](#fieldhandheadersets)
+  * [`#response_date`](#fieldhandheaderresponse_date)
 * [`Fieldhand::NetworkError`](#fieldhandnetworkerror)
 * [`Fieldhand::ProtocolError`](#fieldhandprotocolerror)
   * [`Fieldhand::BadArgumentError`](#fieldhandbadargumenterror)
@@ -288,6 +293,15 @@ Returns XML elements describing this repository as an `Array` of [`Ox::Element`]
 
 As descriptions can be in any format, Fieldhand doesn't attempt to parse descriptions but leaves parsing to the client.
 
+#### `Fieldhand::Identify#response_date`
+
+```ruby
+repository.identify.response_date
+#=> 2017-05-08 11:21:38 +0100
+```
+
+Return the time and date that the response was sent.
+
 ### `Fieldhand::MetadataFormat`
 
 A class to represent a metadata format available from a repository.
@@ -319,6 +333,15 @@ repository.metadata_formats.first.namespace
 
 Return the XML Namespace URI for the format as a [`URI`][URI].
 
+#### `Fieldhand::MetadataFormat#response_date`
+
+```ruby
+repository.metadata_formats.first.response_date
+#=> 2017-05-08 11:21:38 +0100
+```
+
+Return the time and date that the response was sent.
+
 ### `Fieldhand::Set`
 
 A class representing an optional construct for grouping items for the purpose of selective harvesting.
@@ -349,6 +372,15 @@ repository.sets.first.descriptions
 ```
 
 Return an `Array` of [`Ox::Element`][Element]s of any optional and repeatable containers that may hold community-specific XML-encoded data about the set.
+
+#### `Fieldhand::Set#response_date`
+
+```ruby
+repository.sets.first.response_date
+#=> 2017-05-08 11:21:38 +0100
+```
+
+Return the time and date that the response was sent.
 
 ### `Fieldhand::Record`
 
@@ -423,6 +455,15 @@ repository.records.first.about
 
 Return an `Array` of [`Ox::Element`][Element]s of any optional and repeatable containers holding data about the metadata part of the record.
 
+#### `Fieldhand::Record#response_date`
+
+```ruby
+repository.records.first.response_date
+#=> 2017-05-08 11:21:38 +0100
+```
+
+Return the time and date that the response was sent.
+
 ### `Fieldhand::Header`
 
 A class representing the [header](https://www.openarchives.org/OAI/openarchivesprotocol.html#header) of a record:
@@ -483,6 +524,15 @@ repository.identifiers.first.sets
 ```
 
 Return an `Array` of `String` [set specs](#fieldhandsetspec) indicating set memberships of this record.
+
+#### `Fieldhand::Header#response_date`
+
+```ruby
+repository.identifiers.first.response_date
+#=> 2017-05-08 11:21:38 +0100
+```
+
+Return the time and date that the response was sent.
 
 ### `Fieldhand::NetworkError`
 

--- a/lib/fieldhand/header.rb
+++ b/lib/fieldhand/header.rb
@@ -13,10 +13,11 @@ module Fieldhand
   #
   # See https://www.openarchives.org/OAI/openarchivesprotocol.html#header
   class Header
-    attr_reader :element
+    attr_reader :element, :response_date
 
-    def initialize(element)
+    def initialize(element, response_date = Time.now)
       @element = element
+      @response_date = response_date
     end
 
     def deleted?

--- a/lib/fieldhand/identify.rb
+++ b/lib/fieldhand/identify.rb
@@ -6,10 +6,11 @@ module Fieldhand
   #
   # See https://www.openarchives.org/OAI/openarchivesprotocol.html#Identify
   class Identify
-    attr_reader :element
+    attr_reader :element, :response_date
 
-    def initialize(element)
+    def initialize(element, response_date = Time.now)
       @element = element
+      @response_date = response_date
     end
 
     def name

--- a/lib/fieldhand/metadata_format.rb
+++ b/lib/fieldhand/metadata_format.rb
@@ -5,10 +5,11 @@ module Fieldhand
   #
   # See https://www.openarchives.org/OAI/openarchivesprotocol.html#ListMetadataFormats
   class MetadataFormat
-    attr_reader :element
+    attr_reader :element, :response_date
 
-    def initialize(element)
+    def initialize(element, response_date = Time.now)
       @element = element
+      @response_date = response_date
     end
 
     def to_s

--- a/lib/fieldhand/paginator.rb
+++ b/lib/fieldhand/paginator.rb
@@ -1,3 +1,4 @@
+require 'fieldhand/datestamp'
 require 'fieldhand/logger'
 require 'ox'
 require 'cgi'
@@ -46,13 +47,14 @@ module Fieldhand
 
       loop do
         document = ::Ox.parse(request(query.merge('verb' => verb)))
+        response_date = document.root.locate('responseDate[0]/^String').map { |date| Datestamp.parse(date) }.first
 
         document.root.locate('error').each do |error|
           convert_error(error)
         end
 
         document.root.locate(path).each do |item|
-          yield item
+          yield item, response_date
         end
 
         resumption_token = document.root.locate('?/resumptionToken/^String').first

--- a/lib/fieldhand/record.rb
+++ b/lib/fieldhand/record.rb
@@ -5,10 +5,11 @@ module Fieldhand
   #
   # See https://www.openarchives.org/OAI/openarchivesprotocol.html#Record
   class Record
-    attr_reader :element
+    attr_reader :element, :response_date
 
-    def initialize(element)
+    def initialize(element, response_date = Time.now)
       @element = element
+      @response_date = response_date
     end
 
     def deleted?

--- a/lib/fieldhand/repository.rb
+++ b/lib/fieldhand/repository.rb
@@ -23,7 +23,7 @@ module Fieldhand
     def identify
       paginator.
         items('Identify', 'Identify').
-        map { |identify| Identify.new(identify) }.
+        map { |identify, response_date| Identify.new(identify, response_date) }.
         first
     end
 
@@ -35,8 +35,8 @@ module Fieldhand
 
       paginator.
         items('ListMetadataFormats', 'ListMetadataFormats/metadataFormat', arguments).
-        each do |format|
-          yield MetadataFormat.new(format)
+        each do |format, response_date|
+          yield MetadataFormat.new(format, response_date)
         end
     end
 
@@ -45,8 +45,8 @@ module Fieldhand
 
       paginator.
         items('ListSets', 'ListSets/set').
-        each do |set|
-          yield Set.new(set)
+        each do |set, response_date|
+          yield Set.new(set, response_date)
         end
     end
 
@@ -57,8 +57,8 @@ module Fieldhand
 
       paginator.
         items('ListRecords', 'ListRecords/record', query).
-        each do |record|
-          yield Record.new(record)
+        each do |record, response_date|
+          yield Record.new(record, response_date)
         end
     end
 
@@ -69,8 +69,8 @@ module Fieldhand
 
       paginator.
         items('ListIdentifiers', 'ListIdentifiers/header', query).
-        each do |header|
-          yield Header.new(header)
+        each do |header, response_date|
+          yield Header.new(header, response_date)
         end
     end
 
@@ -82,7 +82,7 @@ module Fieldhand
 
       paginator.
         items('GetRecord', 'GetRecord/record', query).
-        map { |record| Record.new(record) }.
+        map { |record, response_date| Record.new(record, response_date) }.
         first
     end
 

--- a/lib/fieldhand/set.rb
+++ b/lib/fieldhand/set.rb
@@ -3,10 +3,11 @@ module Fieldhand
   #
   # See https://www.openarchives.org/OAI/openarchivesprotocol.html#Set
   class Set
-    attr_reader :element
+    attr_reader :element, :response_date
 
-    def initialize(element)
+    def initialize(element, response_date = Time.now)
       @element = element
+      @response_date = response_date
     end
 
     def to_s

--- a/spec/fieldhand/header_spec.rb
+++ b/spec/fieldhand/header_spec.rb
@@ -34,5 +34,14 @@ module Fieldhand
         expect(header.datestamp).to eq(::Date.new(2001, 1, 1))
       end
     end
+
+    describe '#response_date' do
+      it 'returns the passed response date' do
+        element = ::Ox.parse('<header/>')
+        header = described_class.new(element, ::Time.utc(2001, 1, 1, 0, 0, 0))
+
+        expect(header.response_date).to eq(::Time.utc(2001, 1, 1, 0, 0, 0))
+      end
+    end
   end
 end

--- a/spec/fieldhand/identify_spec.rb
+++ b/spec/fieldhand/identify_spec.rb
@@ -39,5 +39,14 @@ module Fieldhand
         expect(identify.earliest_datestamp).to eq(::Date.new(1990, 2, 1))
       end
     end
+
+    describe '#response_date' do
+      it 'returns the passed response date' do
+        element = ::Ox.parse('<Identify/>')
+        identify = described_class.new(element, ::Time.utc(2001, 1, 1, 0, 0, 0))
+
+        expect(identify.response_date).to eq(::Time.utc(2001, 1, 1, 0, 0, 0))
+      end
+    end
   end
 end

--- a/spec/fieldhand/metadata_format_spec.rb
+++ b/spec/fieldhand/metadata_format_spec.rb
@@ -11,5 +11,14 @@ module Fieldhand
         expect(format.to_s).to eq('xoai')
       end
     end
+
+    describe '#response_date' do
+      it 'returns the passed response date' do
+        element = ::Ox.parse('<metadataFormat/>')
+        format = described_class.new(element, ::Time.utc(2001, 1, 1, 0, 0, 0))
+
+        expect(format.response_date).to eq(::Time.utc(2001, 1, 1, 0, 0, 0))
+      end
+    end
   end
 end

--- a/spec/fieldhand/record_spec.rb
+++ b/spec/fieldhand/record_spec.rb
@@ -34,5 +34,14 @@ module Fieldhand
         expect(record.about.size).to eq(2)
       end
     end
+
+    describe '#response_date' do
+      it 'returns the passed response date' do
+        element = ::Ox.parse('<record/>')
+        record = described_class.new(element, ::Time.utc(2001, 1, 1, 0, 0, 0))
+
+        expect(record.response_date).to eq(::Time.utc(2001, 1, 1, 0, 0, 0))
+      end
+    end
   end
 end

--- a/spec/fieldhand/set_spec.rb
+++ b/spec/fieldhand/set_spec.rb
@@ -27,5 +27,14 @@ module Fieldhand
         expect(set.to_s).to eq('A')
       end
     end
+
+    describe '#response_date' do
+      it 'returns the passed response date' do
+        element = ::Ox.parse('<set/>')
+        set = described_class.new(element, ::Time.utc(2001, 1, 1, 0, 0, 0))
+
+        expect(set.response_date).to eq(::Time.utc(2001, 1, 1, 0, 0, 0))
+      end
+    end
   end
 end


### PR DESCRIPTION
So that we can use the date of response to resume requests in future (using from and until arguments), associate every response (e.g. a Header, Record, Set, etc.) with its response date as defined in https://www.openarchives.org/OAI/openarchivesprotocol.html#HTTPResponseFormat