### PR TITLE
Return Strings rather than Ox Elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,10 +286,10 @@ Returns the compression encodings supported by the repository as an `Array` of `
 
 ```ruby
 repository.identify.descriptions
-#=> [#<Ox::Element...>]
+#=> ["<description>..."]
 ```
 
-Returns XML elements describing this repository as an `Array` of [`Ox::Element`][Element]s.
+Returns descriptions of this repository as an `Array` of `String`s.
 
 As descriptions can be in any format, Fieldhand doesn't attempt to parse descriptions but leaves parsing to the client.
 
@@ -368,10 +368,10 @@ Return a short human-readable `String` naming the set.
 
 ```ruby
 repository.sets.first.descriptions
-#=> [#<Ox::Element: ...>]
+#=> ["<setDescription>..."]
 ```
 
-Return an `Array` of [`Ox::Element`][Element]s of any optional and repeatable containers that may hold community-specific XML-encoded data about the set.
+Return an `Array` of `String`s of any optional and repeatable containers that may hold community-specific XML-encoded data about the set.
 
 #### `Fieldhand::Set#response_date`
 
@@ -439,10 +439,10 @@ Return an `Array` of `String` [set specs](#fieldhandsetspec) indicating set memb
 
 ```ruby
 repository.records.first.metadata
-#=> #<Ox::Element: ...>
+#=> "<metadata>..."
 ```
 
-Return a single manifestation of the metadata from a record as [`Ox::Element`][Element]s or `nil` if this is a deleted record.
+Return a single manifestation of the metadata from a record as a `String` or `nil` if this is a deleted record.
 
 As the metadata can be in [any format supported by the repository](#fieldhandrepositorymetadata_formatsidentifier), Fieldhand doesn't attempt to parse the metadata but leaves parsing to the client.
 
@@ -450,10 +450,10 @@ As the metadata can be in [any format supported by the repository](#fieldhandrep
 
 ```ruby
 repository.records.first.about
-#=> [#<Ox::Element: ...>]
+#=> ["<about>..."]
 ```
 
-Return an `Array` of [`Ox::Element`][Element]s of any optional and repeatable containers holding data about the metadata part of the record.
+Return an `Array` of `String`s of any optional and repeatable containers holding data about the metadata part of the record.
 
 #### `Fieldhand::Record#response_date`
 
@@ -585,7 +585,6 @@ This can be used to rescue all the following child error types.
   [Enumerator]: https://ruby-doc.org/core/Enumerator.html
   [Time]: https://ruby-doc.org/core/Time.html
   [URI]: https://ruby-doc.org/stdlib/libdoc/uri/rdoc/URI.html
-  [Element]: http://www.rubydoc.info/github/ohler55/ox/Ox/Element
 
 ## Acknowledgements
 

--- a/lib/fieldhand/record.rb
+++ b/lib/fieldhand/record.rb
@@ -1,4 +1,5 @@
 require 'fieldhand/header'
+require 'ox'
 
 module Fieldhand
   # A record is metadata expressed in a single format.
@@ -33,11 +34,11 @@ module Fieldhand
     end
 
     def metadata
-      @metadata ||= element.locate('metadata[0]').first
+      @metadata ||= element.locate('metadata[0]').map { |metadata| Ox.dump(metadata) }.first
     end
 
     def about
-      @about ||= element.locate('about')
+      @about ||= element.locate('about').map { |about| Ox.dump(about) }
     end
 
     def header

--- a/lib/fieldhand/set.rb
+++ b/lib/fieldhand/set.rb
@@ -1,3 +1,5 @@
+require 'ox'
+
 module Fieldhand
   # A set is an optional construct for grouping items for the purpose of selective harvesting.
   #
@@ -23,7 +25,7 @@ module Fieldhand
     end
 
     def descriptions
-      @descriptions ||= element.locate('setDescription')
+      @descriptions ||= element.locate('setDescription').map { |description| Ox.dump(description) }
     end
   end
 end

--- a/spec/fieldhand/record_spec.rb
+++ b/spec/fieldhand/record_spec.rb
@@ -19,6 +19,22 @@ module Fieldhand
       end
     end
 
+    describe '#metadata' do
+      it 'returns nil if there is no metadata' do
+        element = ::Ox.parse('<record/>')
+        record = described_class.new(element)
+
+        expect(record.metadata).to be_nil
+      end
+
+      it 'returns the metadata as a string' do
+        element = ::Ox.parse('<record><metadata>Foo</metadata></record>')
+        record = described_class.new(element)
+
+        expect(record.metadata).to eq("\n<metadata>Foo</metadata>\n")
+      end
+    end
+
     describe '#about' do
       it 'returns an empty array if there are no about elements' do
         element = ::Ox.parse('<record/>')
@@ -32,6 +48,13 @@ module Fieldhand
         record = described_class.new(element)
 
         expect(record.about.size).to eq(2)
+      end
+
+      it 'returns about sections as strings' do
+        element = ::Ox.parse('<record><about>Foo</about><about>Bar</about></record>')
+        record = described_class.new(element)
+
+        expect(record.about).to contain_exactly("\n<about>Foo</about>\n", "\n<about>Bar</about>\n")
       end
     end
 

--- a/spec/fieldhand/set_spec.rb
+++ b/spec/fieldhand/set_spec.rb
@@ -17,6 +17,14 @@ module Fieldhand
 
         expect(set.descriptions.size).to eq(2)
       end
+
+      it 'returns descriptions as strings' do
+        element = ::Ox.parse('<set><setDescription>Foo</setDescription><setDescription>Bar</setDescription></set>')
+        set = described_class.new(element)
+
+        expect(set.descriptions).
+          to contain_exactly("\n<setDescription>Foo</setDescription>\n", "\n<setDescription>Bar</setDescription>\n")
+      end
     end
 
     describe '#to_s' do


### PR DESCRIPTION
Rather than having users handle Ox Element objects for unparsable parts of records (e.g. set descriptions, record metadata), return raw strings instead. In this way, we don't couple ourselves too tightly to a third party dependency and users can use whichever XML parser they prefer.

Unfortunately, we do this by parsing the entire document with Ox and then selectively dump that parsed representation back into a String which is a little wasteful. I did attempt to switch to SAX parsing instead to avoid parsing parts of the XML we don't want to transform into objects but my first attempt was _slower_, not _faster_.