### PR TITLE
Added support for retrieving a Fieldhand record as a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.6.0] - 2017-07-26
+### Added
+- Added support for retrieving a Fieldhand record as a string
+- Added unicode character support for retrieving Fieldhand record metadata as a string
+
 ## [0.5.0] - 2017-07-11
 ### Changed
 - Fieldhand will raise a new subclass of Network Error for unexpected
@@ -38,3 +43,4 @@ project adheres to [Semantic Versioning](http://semver.org/).
 [0.3.1]: https://github.com/altmetric/fieldhand/releases/tag/v0.3.1
 [0.4.0]: https://github.com/altmetric/fieldhand/releases/tag/v0.4.0
 [0.5.0]: https://github.com/altmetric/fieldhand/releases/tag/v0.5.0
+[0.6.0]: https://github.com/altmetric/fieldhand/releases/tag/v0.6.0

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Ruby library for harvesting metadata from [OAI-PMH](https://www.openarchives.org/OAI/openarchivesprotocol.html) repositories.
 
-**Current version:** 0.5.0  
+**Current version:** 0.5.0
 **Supported Ruby versions:** 1.8.7, 1.9.2, 1.9.3, 2.0, 2.1, 2.2
 
 ## Installation
@@ -77,6 +77,7 @@ repository.get('oai:www.example.com:12345')
   * [`#identifier`](#fieldhandrecordidentifier)
   * [`#datestamp`](#fieldhandrecorddatestamp)
   * [`#sets`](#fieldhandrecordsets)
+  * [`#dump`](#fieldhandrecorddump)
   * [`#metadata`](#fieldhandrecordmetadata)
   * [`#about`](#fieldhandrecordabout)
   * [`#response_date`](#fieldhandrecordresponse_date)
@@ -436,6 +437,17 @@ repository.records.first.sets
 ```
 
 Return an `Array` of `String` [set specs](#fieldhandsetspec) indicating set memberships of this record.
+
+#### `Fieldhand::Record#dump`
+
+```ruby
+repository.records.first.dump
+#=> "<record><metadata>...</metadata><record>"
+```
+
+Return the record as a `String` of XML.
+
+As the record can be in [any format supported by the repository](#fieldhandrepositorymetadata_formatsidentifier), Fieldhand doesn't attempt to parse the record but leaves parsing to the client.
 
 #### `Fieldhand::Record#metadata`
 

--- a/README.md
+++ b/README.md
@@ -2,19 +2,19 @@
 
 A Ruby library for harvesting metadata from [OAI-PMH](https://www.openarchives.org/OAI/openarchivesprotocol.html) repositories.
 
-**Current version:** 0.5.0
+**Current version:** 0.6.0  
 **Supported Ruby versions:** 1.8.7, 1.9.2, 1.9.3, 2.0, 2.1, 2.2
 
 ## Installation
 
 ```
-gem install fieldhand -v '~> 0.5'
+gem install fieldhand -v '~> 0.6'
 ```
 
 Or, in your `Gemfile`:
 
 ```ruby
-gem 'fieldhand', '~> 0.5'
+gem 'fieldhand', '~> 0.6'
 ```
 
 ## Usage
@@ -77,7 +77,7 @@ repository.get('oai:www.example.com:12345')
   * [`#identifier`](#fieldhandrecordidentifier)
   * [`#datestamp`](#fieldhandrecorddatestamp)
   * [`#sets`](#fieldhandrecordsets)
-  * [`#dump`](#fieldhandrecorddump)
+  * [`#to_xml`](#fieldhandrecordto_xml)
   * [`#metadata`](#fieldhandrecordmetadata)
   * [`#about`](#fieldhandrecordabout)
   * [`#response_date`](#fieldhandrecordresponse_date)
@@ -438,16 +438,14 @@ repository.records.first.sets
 
 Return an `Array` of `String` [set specs](#fieldhandsetspec) indicating set memberships of this record.
 
-#### `Fieldhand::Record#dump`
+#### `Fieldhand::Record#to_xml`
 
 ```ruby
-repository.records.first.dump
+repository.records.first.to_xml
 #=> "<record><metadata>...</metadata><record>"
 ```
 
 Return the record as a `String` of XML.
-
-As the record can be in [any format supported by the repository](#fieldhandrepositorymetadata_formatsidentifier), Fieldhand doesn't attempt to parse the record but leaves parsing to the client.
 
 #### `Fieldhand::Record#metadata`
 

--- a/fieldhand.gemspec
+++ b/fieldhand.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'fieldhand'
-  s.version = '0.5.0'
+  s.version = '0.6.0'
   s.summary = 'An OAI-PMH harvester'
   s.description = <<-EOF
     A library to harvest metadata from OAI-PMH repositories.

--- a/lib/fieldhand/record.rb
+++ b/lib/fieldhand/record.rb
@@ -54,7 +54,7 @@ module Fieldhand
     #
     # As metadata can be in any format, Fieldhand does not attempt to parse it but leave that to the user.
     def metadata
-      @metadata ||= element.locate('metadata[0]').map { |metadata| Ox.dump(metadata) }.first
+      @metadata ||= element.locate('metadata[0]').map { |metadata| Ox.dump(metadata, :encoding => 'utf-8') }.first
     end
 
     # Return any about elements describing the metadata of this record as an array of strings.

--- a/lib/fieldhand/record.rb
+++ b/lib/fieldhand/record.rb
@@ -45,6 +45,11 @@ module Fieldhand
       header.sets
     end
 
+    # Return this whole item as a string
+    def to_xml
+      Ox.dump(element, :encoding => 'utf-8')
+    end
+
     # Return the single manifestation of the metadata of this item as a string, if present.
     #
     # As metadata can be in any format, Fieldhand does not attempt to parse it but leave that to the user.

--- a/spec/fieldhand/record_spec.rb
+++ b/spec/fieldhand/record_spec.rb
@@ -35,6 +35,13 @@ module Fieldhand
 
         expect(record.metadata).to eq("\n<metadata>Foo</metadata>\n")
       end
+
+      it 'returns the metadata with unicode characters as a string' do
+        element = ::Ox.parse('<record><metadata>ψFooϨ</metadata></record>')
+        record = described_class.new(element)
+
+        expect(record.metadata).to eq("\n<metadata>ψFooϨ</metadata>\n")
+      end
     end
 
     describe '#to_xml' do

--- a/spec/fieldhand/record_spec.rb
+++ b/spec/fieldhand/record_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'fieldhand/record'
 require 'ox'
 
@@ -32,6 +34,39 @@ module Fieldhand
         record = described_class.new(element)
 
         expect(record.metadata).to eq("\n<metadata>Foo</metadata>\n")
+      end
+    end
+
+    describe '#to_xml' do
+      it 'returns the whole element even if there is no metadata as a string' do
+        element = ::Ox.parse('<record/>')
+        record = described_class.new(element)
+
+        expect(record.to_xml).to eq("\n<record/>\n")
+      end
+
+      it 'returns the whole element as a string' do
+        element = ::Ox.parse("<record><metadata>Foo</metadata></record>")
+        record = described_class.new(element)
+
+        expect(record.to_xml).to eq(<<-XML)
+
+<record>
+  <metadata>Foo</metadata>
+</record>
+        XML
+      end
+
+      it 'returns the whole element with unicode characters as a string' do
+        element = ::Ox.parse("<record><metadata>ψFooϨ</metadata></record>")
+        record = described_class.new(element)
+
+        expect(record.to_xml).to eq(<<-XML)
+
+<record>
+  <metadata>ψFooϨ</metadata>
+</record>
+        XML
       end
     end
 


### PR DESCRIPTION
The `#dump` method on a `Fieldhand::Record` returns the item as a string in
its original format.