### PR TITLE
Remove whitespace when outputing an element or its metdata

### DIFF
--- a/lib/fieldhand/record.rb
+++ b/lib/fieldhand/record.rb
@@ -47,14 +47,14 @@ module Fieldhand
 
     # Return this whole item as a string
     def to_xml
-      Ox.dump(element, :encoding => 'utf-8')
+      Ox.dump(element, :encoding => 'utf-8', :indent => 0)
     end
 
     # Return the single manifestation of the metadata of this item as a string, if present.
     #
     # As metadata can be in any format, Fieldhand does not attempt to parse it but leave that to the user.
     def metadata
-      @metadata ||= element.locate('metadata[0]').map { |metadata| Ox.dump(metadata, :encoding => 'utf-8') }.first
+      @metadata ||= element.locate('metadata[0]').map { |metadata| Ox.dump(metadata, :encoding => 'utf-8', :indent => 0) }.first
     end
 
     # Return any about elements describing the metadata of this record as an array of strings.

--- a/spec/fieldhand/record_spec.rb
+++ b/spec/fieldhand/record_spec.rb
@@ -59,7 +59,7 @@ module Fieldhand
         expect(record.to_xml).to eq(<<-XML)
 
 <record>
-  <metadata>Foo</metadata>
+<metadata>Foo</metadata>
 </record>
         XML
       end
@@ -71,7 +71,7 @@ module Fieldhand
         expect(record.to_xml).to eq(<<-XML)
 
 <record>
-  <metadata>ψFooϨ</metadata>
+<metadata>ψFooϨ</metadata>
 </record>
         XML
       end


### PR DESCRIPTION
Im not sure about this being on Fieldhand's side, but it seemed like the right place to do it. This is due to us outputting the source as follows:
```
"source": "\n<record>\n  <header>\n    <!-- citation-id: 61388204; type: JOURNAL_ARTICLE; -->\n    <identifier>info:doi/10.1074/jbc.M112.429738</identifier>\n    <datestamp>2017-06-24</datestamp>\n    <setSpec>J</setSpec>\n    <setSpec>J:10.1074</setSpec>\n    <setSpec>J:10.1074:4173</setSpec>\n  </header>\n  <!-- org.crossref.xs.xml.XmlSchemaInfo@ae01b520 -->\n  <metadata>\n    <crossref xmlns=\"http://www.crossref.org/xschema/1.1\" xsi:schemaLocation=\"http://www.crossref.org/xschema/1.1 http://www.crossref.org/schema/unixref1.1.xsd\">\n      <journal>\n        <journal_metadata language=\"en\">\n          <full_title>Journal of Biological Chemistry</full_title>\n          <abbrev_title>J. Biol. Chem.</abbrev_title>\n          <issn media_type=\"print\">0021-9258</issn>\n          <issn media_type=\"electronic\">1083-351X</issn>\n        </journal_metadata>\n        <journal_issue>\n          <publication_date media_type=\"online\">\n            <month>05</month>\n            <day>10</day>\n            <year>2013</year>\n          </publication_date>\n          <publication_date media_type=\"print\">\n            <month>05</month>\n            <day>10</day>\n            <year>2013</year>\n          </publication_date>\n          <journal_volume>\n            <volume>288</volume>\n          </journal_volume>\n          <issue>19</issue>\n        </journal_issue>\n        <journal_article publication_type=\"full_text\">\n          <titles>\n            <title>Methionine Adenosyltransferase II-dependent Histone H3K9 Methylation at the\n              <i>COX-2</i>Gene Locus</title>\n          </titles>\n          <contributors>\n            <person_name contributor_role=\"author\" sequence=\"first\">\n              <given_name>Yohei</given_name>\n              <surname>Kera</surname>\n            </person_name>\n            <person_name contributor_role=\"author\" sequence=\"additional\">\n              <given_name>Yasutake</given_name>\n              <surname>Katoh</surname>\n            </person_name>\n            <person_name contributor_role=\"author\" sequence=\"additional\">\n              <given_name>Mineto</given_name>\n              <surname>Ohta</surname>\n            </person_name>\n            <person_name contributor_role=\"author\" sequence=\"additional\">\n              <given_name>Mitsuyo</given_name>\n              <surname>Matsumoto</surname>\n            </person_name>\n            <person_name contributor_role=\"author\" sequence=\"additional\">\n              <given_name>Teruko</given_name>\n              <surname>Takano-Yamamoto</surname>\n            </person_name>\n            <person_name contributor_role=\"author\" sequence=\"additional\">\n              <given_name>Kazuhiko</given_name>\n              <surname>Igarashi</surname>\n            </person_name>\n....
```
instead of something like this:
```
"source": "<record>\n<header>\n<!-- type: journal_article; -->\n    <identifier>info:doi/10.1007/s00271-010-0224-6</identifier>\n    <datestamp>2013-03-21</datestamp>\n    <setSpec>J</setSpec>\n    <setSpec>J:10.1007</setSpec>\n    <setSpec>J:10.1007:1083</setSpec>\n</header>\n<metadata><crossref xmlns=\"http://www.crossref.org/xschema/1.1\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://www.crossref.org/xschema/1.1 http://www.crossref.org/schema/unixref1.1.xsd\"><journal><journal_metadata language=\"en\"><full_title>Irrigation Science</full_title><abbrev_title>Irrig Sci</abbrev_title><issn media_type=\"print\">0342-7188</issn><issn media_type=\"electronic\">1432-1319</issn></journal_metadata><journal_article publication_type=\"full_text\"><titles><title>Assessment of a 4-input artificial neural network for ETo estimation through data set scanning procedures</title></titles><contributors><person_name contributor_role=\"author\" sequence=\"first\"><given_name>Pau</given_name><surname>Martí</surname></person_name><person_name contributor_role=\"author\" sequence=\"additional\"><given_name>Juan</given_name><surname>Manzano</surname></person_name><person_name contributor_role=\"author\" sequence=\"additional\"....
```

I couldn't find any options for the new lines though: http://www.ohler.com/ox/doc/Ox.html#default_options-class_method