### PR TITLE
Return a compressed output for an element or its metdata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.7.0] - 2017-07-27
+### Changed
+- Changed methods that output the string version of xml to return a compressed version of the xml
+
 ## [0.6.0] - 2017-07-26
 ### Added
 - Added support for retrieving a Fieldhand record as a string
@@ -44,3 +48,4 @@ project adheres to [Semantic Versioning](http://semver.org/).
 [0.4.0]: https://github.com/altmetric/fieldhand/releases/tag/v0.4.0
 [0.5.0]: https://github.com/altmetric/fieldhand/releases/tag/v0.5.0
 [0.6.0]: https://github.com/altmetric/fieldhand/releases/tag/v0.6.0
+[0.7.0]: https://github.com/altmetric/fieldhand/releases/tag/v0.7.0

--- a/README.md
+++ b/README.md
@@ -2,19 +2,19 @@
 
 A Ruby library for harvesting metadata from [OAI-PMH](https://www.openarchives.org/OAI/openarchivesprotocol.html) repositories.
 
-**Current version:** 0.6.0  
+**Current version:** 0.7.0  
 **Supported Ruby versions:** 1.8.7, 1.9.2, 1.9.3, 2.0, 2.1, 2.2
 
 ## Installation
 
 ```
-gem install fieldhand -v '~> 0.6'
+gem install fieldhand -v '~> 0.7'
 ```
 
 Or, in your `Gemfile`:
 
 ```ruby
-gem 'fieldhand', '~> 0.6'
+gem 'fieldhand', '~> 0.7'
 ```
 
 ## Usage

--- a/fieldhand.gemspec
+++ b/fieldhand.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'fieldhand'
-  s.version = '0.6.0'
+  s.version = '0.7.0'
   s.summary = 'An OAI-PMH harvester'
   s.description = <<-EOF
     A library to harvest metadata from OAI-PMH repositories.

--- a/lib/fieldhand/record.rb
+++ b/lib/fieldhand/record.rb
@@ -47,14 +47,14 @@ module Fieldhand
 
     # Return this whole item as a string
     def to_xml
-      Ox.dump(element, :encoding => 'utf-8')
+      Ox.dump(element, :encoding => 'utf-8', :indent => -1)
     end
 
     # Return the single manifestation of the metadata of this item as a string, if present.
     #
     # As metadata can be in any format, Fieldhand does not attempt to parse it but leave that to the user.
     def metadata
-      @metadata ||= element.locate('metadata[0]').map { |metadata| Ox.dump(metadata, :encoding => 'utf-8') }.first
+      @metadata ||= element.locate('metadata[0]').map { |metadata| Ox.dump(metadata, :encoding => 'utf-8', :indent => -1) }.first
     end
 
     # Return any about elements describing the metadata of this record as an array of strings.

--- a/spec/fieldhand/record_spec.rb
+++ b/spec/fieldhand/record_spec.rb
@@ -33,14 +33,14 @@ module Fieldhand
         element = ::Ox.parse('<record><metadata>Foo</metadata></record>')
         record = described_class.new(element)
 
-        expect(record.metadata).to eq("\n<metadata>Foo</metadata>\n")
+        expect(record.metadata).to eq("<metadata>Foo</metadata>\n")
       end
 
       it 'returns the metadata with unicode characters as a string' do
         element = ::Ox.parse('<record><metadata>ψFooϨ</metadata></record>')
         record = described_class.new(element)
 
-        expect(record.metadata).to eq("\n<metadata>ψFooϨ</metadata>\n")
+        expect(record.metadata).to eq("<metadata>ψFooϨ</metadata>\n")
       end
     end
 
@@ -49,31 +49,21 @@ module Fieldhand
         element = ::Ox.parse('<record/>')
         record = described_class.new(element)
 
-        expect(record.to_xml).to eq("\n<record/>\n")
+        expect(record.to_xml).to eq("<record/>\n")
       end
 
       it 'returns the whole element as a string' do
         element = ::Ox.parse("<record><metadata>Foo</metadata></record>")
         record = described_class.new(element)
 
-        expect(record.to_xml).to eq(<<-XML)
-
-<record>
-  <metadata>Foo</metadata>
-</record>
-        XML
+        expect(record.to_xml).to eq("<record><metadata>Foo</metadata></record>\n")
       end
 
       it 'returns the whole element with unicode characters as a string' do
         element = ::Ox.parse("<record><metadata>ψFooϨ</metadata></record>")
         record = described_class.new(element)
 
-        expect(record.to_xml).to eq(<<-XML)
-
-<record>
-  <metadata>ψFooϨ</metadata>
-</record>
-        XML
+        expect(record.to_xml).to eq("<record><metadata>ψFooϨ</metadata></record>\n")
       end
     end
 


### PR DESCRIPTION
When extracting the original xml for either the element or its metadata,
the current implementation includes the default indentation of 2 spaces for
the heirarchy of the xml. Instead return the most compressed output
possible for the element/metadata, which then gives the user the ability to
choose how to format the xml.