### PR TITLE
Add timeout option to the Repository

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,5 @@ gemspec
 
 group :test do
   gem 'rake', '~> 10.5'
+  gem 'ox', '~> 2.5', '< 2.7'
 end

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ repository.get('oai:www.example.com:12345')
 ## API Documentation
 
 * [`Fieldhand::Repository`](#fieldhandrepository)
-  * [`.new(uri[, logger])`](#fieldhandrepositorynewuri-logger)
+  * [`.new(uri[, options])`](#fieldhandrepositorynewuri-options)
   * [`#identify`](#fieldhandrepositoryidentify)
   * [`#metadata_formats([identifier])`](#fieldhandrepositorymetadata_formatsidentifier)
   * [`#sets`](#fieldhandrepositorysets)
@@ -109,19 +109,20 @@ A class to represent [an OAI-PMH repository](https://www.openarchives.org/OAI/op
 > requests [...]. A repository is managed by a data provider to expose metadata
 > to harvesters.
 
-#### `Fieldhand::Repository.new(uri[, logger])`
+#### `Fieldhand::Repository.new(uri[, options])`
 
 ```ruby
 Fieldhand::Repository.new('http://www.example.com/oai')
 Fieldhand::Repository.new(URI('http://www.example.com/oai'))
-Fieldhand::Repository.new('http://www.example.com/oai', Logger.new(STDOUT))
+Fieldhand::Repository.new('http://www.example.com/oai', :logger => Logger.new(STDOUT), :timeout => 10)
 ```
 
 Return a new [`Repository`](#fieldhandrepository) instance accessible at the given `uri` (specified
 either as a [`URI`][URI] or
-something that can be coerced into a `URI` such as a `String`) with an optional
-[`Logger`](http://ruby-doc.org/stdlib/libdoc/logger/rdoc/Logger.html)-compatible
-`logger`.
+something that can be coerced into a `URI` such as a `String`) with two options passed as a `Hash`:
+
+* `:logger`: a [`Logger`](http://ruby-doc.org/stdlib/libdoc/logger/rdoc/Logger.html)-compatible `logger`, defaults to a platform-specific null logger;
+* `:timeout`: a `Numeric` number of seconds to wait before timing out any HTTP requests, defaults to 60.
 
 #### `Fieldhand::Repository#identify`
 

--- a/lib/fieldhand/options.rb
+++ b/lib/fieldhand/options.rb
@@ -1,0 +1,41 @@
+require 'fieldhand/logger'
+
+module Fieldhand
+  # A wrapper around Repository and Paginator options for backward-compatibility.
+  #
+  # In short, this handles passing a Logger directly or passing it and a timeout as a hash.
+  # Note this attempts to preserve the previous behaviour of passing nil/falsey values as a
+  # logger even though this will cause errors if someone tries to use it that way.
+  class Options
+    attr_reader :logger_or_options
+
+    # Return a new, normalized set of options based on the given value.
+    #
+    # This supports both a `Logger`-compatible object to use for logging directly and a hash of options:
+    #
+    # * :logger - A `Logger`-compatible class for logging the activity of the library, defaults to a platform-specific
+    #             null logger
+    # * :timeout - A `Numeric` number of seconds to wait for any HTTP requests, defaults to 60 seconds
+    def initialize(logger_or_options = {})
+      @logger_or_options = logger_or_options
+    end
+
+    # Return the current timeout in seconds.
+    def timeout
+      options.fetch(:timeout, 60)
+    end
+
+    # Return the current logger.
+    def logger
+      options.fetch(:logger) { Logger.null }
+    end
+
+    private
+
+    def options
+      return logger_or_options if logger_or_options.is_a?(Hash)
+
+      { :logger => logger_or_options }
+    end
+  end
+end

--- a/lib/fieldhand/repository.rb
+++ b/lib/fieldhand/repository.rb
@@ -5,7 +5,7 @@ require 'fieldhand/list_identifiers_parser'
 require 'fieldhand/list_metadata_formats_parser'
 require 'fieldhand/list_records_parser'
 require 'fieldhand/list_sets_parser'
-require 'fieldhand/logger'
+require 'fieldhand/options'
 require 'fieldhand/paginator'
 require 'uri'
 
@@ -14,16 +14,22 @@ module Fieldhand
   #
   # See https://www.openarchives.org/OAI/openarchivesprotocol.html
   class Repository
-    attr_reader :uri, :logger
+    attr_reader :uri, :logger, :timeout
 
-    # Return a new repository with the given base URL and an optional logger.
+    # Return a new repository with the given base URL and an optional logger and timeout.
     #
     # The base URL can be passed as a `URI` or anything that can be parsed as a URI such as a string.
     #
-    # Defaults to using a null logger specific to this platform.
-    def initialize(uri, logger = Logger.null)
+    # For backward compatibility, the second argument can either be a logger or a hash containing
+    # a logger and timeout.
+    #
+    # Defaults to using a null logger specific to this platform and a timeout of 60 seconds.
+    def initialize(uri, logger_or_options = {})
       @uri = uri.is_a?(::URI) ? uri : URI(uri)
-      @logger = logger
+
+      options = Options.new(logger_or_options)
+      @logger = options.logger
+      @timeout = options.timeout
     end
 
     # Send an Identify request to the repository and return an `Identify` response.
@@ -127,7 +133,7 @@ module Fieldhand
     private
 
     def paginator
-      @paginator ||= Paginator.new(uri, logger)
+      @paginator ||= Paginator.new(uri, :logger => logger, :timeout => timeout)
     end
   end
 end

--- a/spec/fieldhand/options_spec.rb
+++ b/spec/fieldhand/options_spec.rb
@@ -1,0 +1,59 @@
+require 'fieldhand/options'
+
+module Fieldhand
+  RSpec.describe Options do
+    describe '#timeout' do
+      it 'defaults to 60 seconds' do
+        options = described_class.new({})
+
+        expect(options.timeout).to eq(60)
+      end
+
+      it 'can be overridden by passing an option' do
+        options = described_class.new(:timeout => 10)
+
+        expect(options.timeout).to eq(10)
+      end
+
+      it 'can be set to nil' do
+        options = described_class.new(:timeout => nil)
+
+        expect(options.timeout).to be_nil
+      end
+    end
+
+    describe '#logger' do
+      it 'defaults to a null logger' do
+        options = described_class.new({})
+
+        expect(options.logger).to be_a(::Logger)
+      end
+
+      it 'can be overridden by passing a logger directly' do
+        logger = ::Logger.new(STDOUT)
+        options = described_class.new(logger)
+
+        expect(options.logger).to eq(logger)
+      end
+
+      it 'can be overridden by passing a logger in an option' do
+        logger = ::Logger.new(STDOUT)
+        options = described_class.new(:logger => logger)
+
+        expect(options.logger).to eq(logger)
+      end
+
+      it 'can be set to nil directly' do
+        options = described_class.new(nil)
+
+        expect(options.logger).to be_nil
+      end
+
+      it 'can be set to nil through an option' do
+        options = described_class.new(:logger => nil)
+
+        expect(options.logger).to be_nil
+      end
+    end
+  end
+end

--- a/spec/fieldhand/paginator_spec.rb
+++ b/spec/fieldhand/paginator_spec.rb
@@ -109,5 +109,41 @@ module Fieldhand
         expect(error.response.body).to eq('Retry after 5 seconds')
       end
     end
+
+    describe '#timeout' do
+      it 'defaults to 60 seconds' do
+        paginator = described_class.new('http://www.example.com/oai')
+
+        expect(paginator.timeout).to eq(60)
+      end
+
+      it 'can be overridden with an option' do
+        paginator = described_class.new('http://www.example.com/oai', :timeout => 10)
+
+        expect(paginator.timeout).to eq(10)
+      end
+    end
+
+    describe '#logger' do
+      it 'defaults to a null logger' do
+        paginator = described_class.new('http://www.example.com/oai')
+
+        expect(paginator.logger).to be_a(::Logger)
+      end
+
+      it 'can be overridden with an option' do
+        logger = ::Logger.new(STDOUT)
+        paginator = described_class.new('http://www.example.com/oai', :logger => logger)
+
+        expect(paginator.logger).to eq(logger)
+      end
+
+      it 'can be overridden by passing as a second argument for historic reasons' do
+        logger = ::Logger.new(STDOUT)
+        paginator = described_class.new('http://www.example.com/oai', logger)
+
+        expect(paginator.logger).to eq(logger)
+      end
+    end
   end
 end

--- a/spec/fieldhand/repository_spec.rb
+++ b/spec/fieldhand/repository_spec.rb
@@ -187,5 +187,41 @@ module Fieldhand
           to have_attributes(:identifier => 'oai:oai.datacite.org:32356')
       end
     end
+
+    describe '#timeout' do
+      it 'defaults to 60 seconds' do
+        repository = described_class.new('http://www.example.com/oai')
+
+        expect(repository.timeout).to eq(60)
+      end
+
+      it 'can be overridden with an option' do
+        repository = described_class.new('http://www.example.com/oai', :timeout => 10)
+
+        expect(repository.timeout).to eq(10)
+      end
+    end
+
+    describe '#logger' do
+      it 'defaults to a null logger' do
+        repository = described_class.new('http://www.example.com/oai')
+
+        expect(repository.logger).to be_a(::Logger)
+      end
+
+      it 'can be overridden with an option' do
+        logger = ::Logger.new(STDOUT)
+        repository = described_class.new('http://www.example.com/oai', :logger => logger)
+
+        expect(repository.logger).to eq(logger)
+      end
+
+      it 'can be overridden by passing as a second argument for historic reasons' do
+        logger = ::Logger.new(STDOUT)
+        repository = described_class.new('http://www.example.com/oai', logger)
+
+        expect(repository.logger).to eq(logger)
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require 'date'
 require 'webmock/rspec'
 
 RSpec.configure do |config|


### PR DESCRIPTION
GitHub: https://github.com/altmetric/fieldhand/issues/9

Allow users to set an HTTP timeout in seconds which will be used by the underlying HTTP client. It currently defaults to 60 seconds to match the defaults from Ruby 2.3 onwards.

Note this retains API compatibility with previous versions of Fieldhand by allowing users to pass a Logger directly or by passing the new style of options as a Hash.