### PR TITLE
Support authorization via bearer tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,15 +114,16 @@ A class to represent [an OAI-PMH repository](https://www.openarchives.org/OAI/op
 ```ruby
 Fieldhand::Repository.new('http://www.example.com/oai')
 Fieldhand::Repository.new(URI('http://www.example.com/oai'))
-Fieldhand::Repository.new('http://www.example.com/oai', :logger => Logger.new(STDOUT), :timeout => 10)
+Fieldhand::Repository.new('http://www.example.com/oai', :logger => Logger.new(STDOUT), :timeout => 10, :bearer_token => 'decafbad')
 ```
 
 Return a new [`Repository`](#fieldhandrepository) instance accessible at the given `uri` (specified
 either as a [`URI`][URI] or
-something that can be coerced into a `URI` such as a `String`) with two options passed as a `Hash`:
+something that can be coerced into a `URI` such as a `String`) with three options passed as a `Hash`:
 
 * `:logger`: a [`Logger`](http://ruby-doc.org/stdlib/libdoc/logger/rdoc/Logger.html)-compatible `logger`, defaults to a platform-specific null logger;
-* `:timeout`: a `Numeric` number of seconds to wait before timing out any HTTP requests, defaults to 60.
+* `:timeout`: a `Numeric` number of seconds to wait before timing out any HTTP requests, defaults to 60;
+* `:bearer_token`: a `String` bearer token to authorize any HTTP requests, defaults to `nil`.
 
 #### `Fieldhand::Repository#identify`
 

--- a/lib/fieldhand/options.rb
+++ b/lib/fieldhand/options.rb
@@ -16,6 +16,7 @@ module Fieldhand
     # * :logger - A `Logger`-compatible class for logging the activity of the library, defaults to a platform-specific
     #             null logger
     # * :timeout - A `Numeric` number of seconds to wait for any HTTP requests, defaults to 60 seconds
+    # * :bearer_token - A `String` bearer token to use when sending any HTTP requests, defaults to nil
     def initialize(logger_or_options = {})
       @logger_or_options = logger_or_options
     end
@@ -28,6 +29,11 @@ module Fieldhand
     # Return the current logger.
     def logger
       options.fetch(:logger) { Logger.null }
+    end
+
+    # Return the current bearer token.
+    def bearer_token
+      options[:bearer_token]
     end
 
     private

--- a/lib/fieldhand/repository.rb
+++ b/lib/fieldhand/repository.rb
@@ -14,22 +14,23 @@ module Fieldhand
   #
   # See https://www.openarchives.org/OAI/openarchivesprotocol.html
   class Repository
-    attr_reader :uri, :logger, :timeout
+    attr_reader :uri, :logger, :timeout, :bearer_token
 
-    # Return a new repository with the given base URL and an optional logger and timeout.
+    # Return a new repository with the given base URL and an optional logger, timeout and bearer token.
     #
     # The base URL can be passed as a `URI` or anything that can be parsed as a URI such as a string.
     #
     # For backward compatibility, the second argument can either be a logger or a hash containing
-    # a logger and timeout.
+    # a logger, timeout and bearer token.
     #
-    # Defaults to using a null logger specific to this platform and a timeout of 60 seconds.
+    # Defaults to using a null logger specific to this platform, a timeout of 60 seconds and no bearer token.
     def initialize(uri, logger_or_options = {})
       @uri = uri.is_a?(::URI) ? uri : URI(uri)
 
       options = Options.new(logger_or_options)
       @logger = options.logger
       @timeout = options.timeout
+      @bearer_token = options.bearer_token
     end
 
     # Send an Identify request to the repository and return an `Identify` response.
@@ -133,7 +134,7 @@ module Fieldhand
     private
 
     def paginator
-      @paginator ||= Paginator.new(uri, :logger => logger, :timeout => timeout)
+      @paginator ||= Paginator.new(uri, :logger => logger, :timeout => timeout, :bearer_token => bearer_token)
     end
   end
 end

--- a/spec/fieldhand/options_spec.rb
+++ b/spec/fieldhand/options_spec.rb
@@ -55,5 +55,19 @@ module Fieldhand
         expect(options.logger).to be_nil
       end
     end
+
+    describe '#bearer_token' do
+      it 'defaults to nil' do
+        options = described_class.new({})
+
+        expect(options.bearer_token).to be_nil
+      end
+
+      it 'can be overridden by passing a token in an option' do
+        options = described_class.new(:bearer_token => 'decafbad')
+
+        expect(options.bearer_token).to eq('decafbad')
+      end
+    end
   end
 end

--- a/spec/fieldhand/paginator_spec.rb
+++ b/spec/fieldhand/paginator_spec.rb
@@ -145,5 +145,38 @@ module Fieldhand
         expect(paginator.logger).to eq(logger)
       end
     end
+
+    describe '#bearer_token' do
+      it 'defaults to nil' do
+        paginator = described_class.new('http://www.example.com/oai')
+
+        expect(paginator.bearer_token).to be_nil
+      end
+
+      it 'can be overridden with an option' do
+        paginator = described_class.new('http://www.example.com/oai', :bearer_token => 'decafbad')
+
+        expect(paginator.bearer_token).to eq('decafbad')
+      end
+
+      it 'sends no authorization header without a bearer token' do
+        request = stub_oai_request('http://www.example.com/oai?verb=Identify', 'identify.xml')
+        paginator = described_class.new('http://www.example.com/oai')
+
+        paginator.items('Identify', IdentifyParser).first
+
+        expect(request).to have_been_requested
+      end
+
+      it 'sends an authorization header with a bearer token' do
+        request = stub_oai_request('http://www.example.com/oai?verb=Identify', 'identify.xml').
+                    with(:headers => { 'Authorization' => 'Bearer decafbad' })
+        paginator = described_class.new('http://www.example.com/oai', :bearer_token => 'decafbad')
+
+        paginator.items('Identify', IdentifyParser).first
+
+        expect(request).to have_been_requested
+      end
+    end
   end
 end

--- a/spec/fieldhand/repository_spec.rb
+++ b/spec/fieldhand/repository_spec.rb
@@ -223,5 +223,29 @@ module Fieldhand
         expect(repository.logger).to eq(logger)
       end
     end
+
+    describe '#bearer_token' do
+      it 'defaults to nil' do
+        repository = described_class.new('http://www.example.com/oai')
+
+        expect(repository.bearer_token).to be_nil
+      end
+
+      it 'can be overridden with an option' do
+        repository = described_class.new('http://www.example.com/oai', :bearer_token => 'decafbad')
+
+        expect(repository.bearer_token).to eq('decafbad')
+      end
+
+      it 'uses the bearer token to authorize HTTP requests' do
+        request = stub_oai_request('http://www.example.com/oai?verb=Identify', 'identify.xml').
+                    with(:headers => { 'Authorization' => 'Bearer decafbad' })
+        repository = described_class.new('http://www.example.com/oai', :bearer_token => 'decafbad')
+
+        repository.identify
+
+        expect(request).to have_been_requested
+      end
+    end
   end
 end


### PR DESCRIPTION
So that users can use Fieldhand with OAI-PMH repositories that demand HTTP bearer tokens for authorization, add a new `bearer_token` option to the repository. This will then be sent in an `Authorization` header with any HTTP request to the repository.

This allows users to use Fieldhand with services such as Crossref's Metadata Plus: https://www.crossref.org/get-started/metadata-plus/

See also https://tools.ietf.org/html/rfc6750