### PR TITLE
Support custom headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ A class to represent [an OAI-PMH repository](https://www.openarchives.org/OAI/op
 Fieldhand::Repository.new('http://www.example.com/oai')
 Fieldhand::Repository.new(URI('http://www.example.com/oai'))
 Fieldhand::Repository.new('http://www.example.com/oai', :logger => Logger.new(STDOUT), :timeout => 10, :bearer_token => 'decafbad')
+Fieldhand::Repository.new('http://www.example.com/oai', :logger => Logger.new(STDOUT), :timeout => 10, :headers => { 'Custom header' => 'decafbad')
 ```
 
 Return a new [`Repository`](#fieldhandrepository) instance accessible at the given `uri` (specified
@@ -124,6 +125,7 @@ something that can be coerced into a `URI` such as a `String`) with three option
 * `:logger`: a [`Logger`](http://ruby-doc.org/stdlib/libdoc/logger/rdoc/Logger.html)-compatible `logger`, defaults to a platform-specific null logger;
 * `:timeout`: a `Numeric` number of seconds to wait before timing out any HTTP requests, defaults to 60;
 * `:bearer_token`: a `String` bearer token to authorize any HTTP requests, defaults to `nil`.
+* `:headers`: a `Hash` containing custom HTTP headers, defaults to `{}`.
 
 #### `Fieldhand::Repository#identify`
 

--- a/lib/fieldhand/options.rb
+++ b/lib/fieldhand/options.rb
@@ -17,6 +17,7 @@ module Fieldhand
     #             null logger
     # * :timeout - A `Numeric` number of seconds to wait for any HTTP requests, defaults to 60 seconds
     # * :bearer_token - A `String` bearer token to use when sending any HTTP requests, defaults to nil
+    # * :headers - A `Hash` containing custom HTTP headers, defaults to {}.
     def initialize(logger_or_options = {})
       @logger_or_options = logger_or_options
     end
@@ -34,6 +35,14 @@ module Fieldhand
     # Return the current bearer token.
     def bearer_token
       options[:bearer_token]
+    end
+
+    # Build custom headers
+    def headers
+      headers = options.fetch(:headers, {})
+      headers['Authorization'] = "Bearer #{bearer_token}" if bearer_token
+
+      headers
     end
 
     private

--- a/lib/fieldhand/paginator.rb
+++ b/lib/fieldhand/paginator.rb
@@ -11,21 +11,21 @@ module Fieldhand
   #
   # See https://www.openarchives.org/OAI/openarchivesprotocol.html#FlowControl
   class Paginator
-    attr_reader :uri, :logger, :timeout, :bearer_token, :http
+    attr_reader :uri, :logger, :timeout, :headers, :http
 
-    # Return a new paginator for the given repository base URI and optional logger, timeout and bearer token.
+    # Return a new paginator for the given repository base URI and optional logger, timeout, bearer token and headers.
     #
     # The URI can be passed as either a `URI` or something that can be parsed as a URI such as a string.
     #
-    # The logger will default to a null logger appropriate to this platform, timeout will default to 60 seconds and the
-    # bearer token will default to nil.
+    # The logger will default to a null logger appropriate to this platform, timeout will default to 60 seconds, the
+    # bearer token will default to nil and headers will default to empty hash.
     def initialize(uri, logger_or_options = {})
       @uri = uri.is_a?(::URI) ? uri : URI(uri)
 
       options = Options.new(logger_or_options)
       @logger = options.logger
       @timeout = options.timeout
-      @bearer_token = options.bearer_token
+      @headers = options.headers
 
       @http = ::Net::HTTP.new(@uri.host, @uri.port)
       @http.read_timeout = @timeout
@@ -104,7 +104,9 @@ module Fieldhand
 
     def authenticated_request(uri)
       request = ::Net::HTTP::Get.new(uri)
-      request['Authorization'] = "Bearer #{bearer_token}" if bearer_token
+      headers.each do |key, value|
+        request[key] = value
+      end
 
       request
     end

--- a/lib/fieldhand/repository.rb
+++ b/lib/fieldhand/repository.rb
@@ -14,23 +14,23 @@ module Fieldhand
   #
   # See https://www.openarchives.org/OAI/openarchivesprotocol.html
   class Repository
-    attr_reader :uri, :logger, :timeout, :bearer_token
+    attr_reader :uri, :logger, :timeout, :headers
 
-    # Return a new repository with the given base URL and an optional logger, timeout and bearer token.
+    # Return a new repository with the given base URL and an optional logger, timeout, bearer token and headers.
     #
     # The base URL can be passed as a `URI` or anything that can be parsed as a URI such as a string.
     #
     # For backward compatibility, the second argument can either be a logger or a hash containing
-    # a logger, timeout and bearer token.
+    # a logger, timeout, bearer token and headers.
     #
-    # Defaults to using a null logger specific to this platform, a timeout of 60 seconds and no bearer token.
+    # Defaults to using a null logger specific to this platform, a timeout of 60 seconds, no bearer token and no headers.
     def initialize(uri, logger_or_options = {})
       @uri = uri.is_a?(::URI) ? uri : URI(uri)
 
       options = Options.new(logger_or_options)
       @logger = options.logger
       @timeout = options.timeout
-      @bearer_token = options.bearer_token
+      @headers = options.headers
     end
 
     # Send an Identify request to the repository and return an `Identify` response.
@@ -134,7 +134,7 @@ module Fieldhand
     private
 
     def paginator
-      @paginator ||= Paginator.new(uri, :logger => logger, :timeout => timeout, :bearer_token => bearer_token)
+      @paginator ||= Paginator.new(uri, :logger => logger, :timeout => timeout, :headers => headers)
     end
   end
 end

--- a/spec/fieldhand/options_spec.rb
+++ b/spec/fieldhand/options_spec.rb
@@ -69,5 +69,25 @@ module Fieldhand
         expect(options.bearer_token).to eq('decafbad')
       end
     end
+
+    describe '#headers' do
+      it 'defaults to an empty hash' do
+        options = described_class.new({})
+
+        expect(options.headers).to be_empty
+      end
+
+      it 'can be overridden by passing headers in an option' do
+        options = described_class.new(:headers => { 'Crossref-Plus-API-Token' => 'decafbad' })
+
+        expect(options.headers).to eq({ 'Crossref-Plus-API-Token' => 'decafbad' })
+      end
+
+      it 'overrides authorization headers with a bearer_token' do
+        options = described_class.new(:headers => { 'Authorization' => 'Bearer aaabbbccc' }, :bearer_token => 'decafbad')
+
+        expect(options.headers).to eq({ 'Authorization' => 'Bearer decafbad' })
+      end
+    end
   end
 end

--- a/spec/fieldhand/paginator_spec.rb
+++ b/spec/fieldhand/paginator_spec.rb
@@ -146,22 +146,23 @@ module Fieldhand
       end
     end
 
-    describe '#bearer_token' do
-      it 'defaults to nil' do
+    describe '#headers' do
+      it 'defaults to an empty hash' do
         paginator = described_class.new('http://www.example.com/oai')
 
-        expect(paginator.bearer_token).to be_nil
+        expect(paginator.headers).to be_empty
       end
 
       it 'can be overridden with an option' do
-        paginator = described_class.new('http://www.example.com/oai', :bearer_token => 'decafbad')
+        paginator = described_class.new('http://www.example.com/oai', :headers => { 'Crossref-Plus-API-Token' => 'Bearer decafbad' })
 
-        expect(paginator.bearer_token).to eq('decafbad')
+        expect(paginator.headers).to eq({ 'Crossref-Plus-API-Token' => 'Bearer decafbad' })
       end
 
-      it 'sends no authorization header without a bearer token' do
-        request = stub_oai_request('http://www.example.com/oai?verb=Identify', 'identify.xml')
-        paginator = described_class.new('http://www.example.com/oai')
+      it 'can add custom headers to HTTP request' do
+        request = stub_oai_request('http://www.example.com/oai?verb=Identify', 'identify.xml').
+                    with(:headers => { 'Crossref-Plus-API-Token' => 'Bearer decafbad' })
+        paginator = described_class.new('http://www.example.com/oai', :headers => { 'Crossref-Plus-API-Token' => 'Bearer decafbad' })
 
         paginator.items('Identify', IdentifyParser).first
 
@@ -170,8 +171,18 @@ module Fieldhand
 
       it 'sends an authorization header with a bearer token' do
         request = stub_oai_request('http://www.example.com/oai?verb=Identify', 'identify.xml').
-                    with(:headers => { 'Authorization' => 'Bearer decafbad' })
-        paginator = described_class.new('http://www.example.com/oai', :bearer_token => 'decafbad')
+                    with(:headers => { 'Authorization' => 'Bearer ewterhtr' })
+        paginator = described_class.new('http://www.example.com/oai', :bearer_token => 'ewterhtr')
+
+        paginator.items('Identify', IdentifyParser).first
+
+        expect(request).to have_been_requested
+      end
+
+      it 'can add multiple custom headers to HTTP request' do
+        request = stub_oai_request('http://www.example.com/oai?verb=Identify', 'identify.xml').
+                    with(:headers => { 'Authorization' => 'Bearer ewterhtr', 'Crossref-Plus-API-Token' => 'decafbad' })
+        paginator = described_class.new('http://www.example.com/oai', :bearer_token => 'ewterhtr', :headers => { 'Crossref-Plus-API-Token' => 'decafbad' })
 
         paginator.items('Identify', IdentifyParser).first
 

--- a/spec/fieldhand/repository_spec.rb
+++ b/spec/fieldhand/repository_spec.rb
@@ -224,23 +224,33 @@ module Fieldhand
       end
     end
 
-    describe '#bearer_token' do
-      it 'defaults to nil' do
+    describe '#headers' do
+      it 'defaults to an empty hash' do
         repository = described_class.new('http://www.example.com/oai')
 
-        expect(repository.bearer_token).to be_nil
+        expect(repository.headers).to be_empty
       end
 
       it 'can be overridden with an option' do
-        repository = described_class.new('http://www.example.com/oai', :bearer_token => 'decafbad')
+        repository = described_class.new('http://www.example.com/oai', :headers => { 'Crossref-Plus-API-Token' => 'Bearer decafbad' })
 
-        expect(repository.bearer_token).to eq('decafbad')
+        expect(repository.headers).to eq({ 'Crossref-Plus-API-Token' => 'Bearer decafbad' })
       end
 
-      it 'uses the bearer token to authorize HTTP requests' do
+      it 'can add custom headers to HTTP request' do
         request = stub_oai_request('http://www.example.com/oai?verb=Identify', 'identify.xml').
-                    with(:headers => { 'Authorization' => 'Bearer decafbad' })
-        repository = described_class.new('http://www.example.com/oai', :bearer_token => 'decafbad')
+                   with(:headers => { 'Crossref-Plus-API-Token' => 'Bearer decafbad' })
+        repository = described_class.new('http://www.example.com/oai', :headers => { 'Crossref-Plus-API-Token' => 'Bearer decafbad' })
+
+        repository.identify
+
+        expect(request).to have_been_requested
+      end
+
+      it 'can use a bearer token to authorize HTTP requests' do
+        request = stub_oai_request('http://www.example.com/oai?verb=Identify', 'identify.xml').
+                    with(:headers => { 'Authorization' => 'Bearer fhsfag' })
+        repository = described_class.new('http://www.example.com/oai', :bearer_token => 'fhsfag')
 
         repository.identify
 


### PR DESCRIPTION
Add a news `headers` option, so users can use Fieldhand with OAI-PMH repositories with custom HTTP headers. 

