### PR TITLE
Strip `oai` namespace prefix from XML.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ A class to represent [an OAI-PMH repository](https://www.openarchives.org/OAI/op
 Fieldhand::Repository.new('http://www.example.com/oai')
 Fieldhand::Repository.new(URI('http://www.example.com/oai'))
 Fieldhand::Repository.new('http://www.example.com/oai', :logger => Logger.new(STDOUT), :timeout => 10, :bearer_token => 'decafbad')
-Fieldhand::Repository.new('http://www.example.com/oai', :logger => Logger.new(STDOUT), :timeout => 10, :headers => { 'Custom header' => 'decafbad')
+Fieldhand::Repository.new('http://www.example.com/oai', :logger => Logger.new(STDOUT), :timeout => 10, :headers => { 'Custom header' => 'decafbad' })
 ```
 
 Return a new [`Repository`](#fieldhandrepository) instance accessible at the given `uri` (specified
@@ -126,7 +126,7 @@ something that can be coerced into a `URI` such as a `String`) with three option
 * `:timeout`: a `Numeric` number of seconds to wait before timing out any HTTP requests, defaults to 60;
 * `:bearer_token`: a `String` bearer token to authorize any HTTP requests, defaults to `nil`.
 * `:headers`: a `Hash` containing custom HTTP headers, defaults to `{}`.
-
+ 
 #### `Fieldhand::Repository#identify`
 
 ```ruby

--- a/lib/fieldhand/response_parser.rb
+++ b/lib/fieldhand/response_parser.rb
@@ -53,7 +53,7 @@ module Fieldhand
 
     # Return the root element of the parsed document.
     def root
-      @root ||= ::Ox.parse(response).root
+      @root ||= ::Ox.load(response, :strip_namespace => 'oai').root
     end
 
     private

--- a/spec/fixtures/get_record_with_namespace.xml
+++ b/spec/fixtures/get_record_with_namespace.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+  <responseDate>2018-10-22T06:44:14Z</responseDate>
+  <request verb="GetRecord" identifier="123456" metadataPrefix="marcxml">http://example.com</request>
+  <GetRecord>
+    <oai:record>
+      <oai:header>
+        <oai:identifier>123456</oai:identifier>
+        <oai:datestamp>2004-06-09</oai:datestamp>
+      </oai:header>
+      <oai:metadata>
+        <collection>
+          <record>
+          </record>
+        </collection>
+      </oai:metadata>
+    </oai:record>
+  </GetRecord>
+</OAI-PMH>

--- a/spec/fixtures/list_records_with_namespaces.xml
+++ b/spec/fixtures/list_records_with_namespaces.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+   <responseDate>2018-11-08T09:33:33Z</responseDate>
+   <request from="2018-11-08" metadataPrefix="marcxml" until="2018-11-08" verb="ListRecords">http://example.com</request>
+   <ListRecords>
+      <oai:record>
+         <oai:header>
+            <oai:identifier>123456</oai:identifier>
+            <oai:datestamp>2018-11-08</oai:datestamp>
+         </oai:header>
+         <oai:metadata>
+            <collection>
+               <record>
+               </record>
+            </collection>
+         </oai:metadata>
+      </oai:record>
+      <oai:record>
+         <oai:header>
+            <oai:identifier>314567</oai:identifier>
+            <oai:datestamp>2018-11-08</oai:datestamp>
+         </oai:header>
+         <oai:metadata>
+            <collection>
+               <record>
+               </record>
+            </collection>
+         </oai:metadata>
+      </oai:record>
+   </ListRecords>
+</OAI-PMH>


### PR DESCRIPTION
So that users can use Fieldhand with OAI-PMH repositories containing
namespace, strip an `oai` namespace which according to documentation
below should be the only namespace allowed.

http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd